### PR TITLE
PEP8 and Python 3 Compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,25 @@
 
 This is a python PSNR calculator tool
 
-
 ## How to install (Linux)
 
-1. Install Python 2.7 if you dont have it in your computer.
+1. Install Python 3.5 if you dont have it in your computer.
 
 2. Open a new terminal and type:
 
   ```
-  sudo apt-get install python-pip
-  sudo pip install numpy
-  sudo pip install pillow
+  # apt-get install python3-pip
+  # pip3 install numpy
+  # pip3 install pillow
   ```
 
 3. Go to the path where example.py is and execute it with the command:
 
   ```
-  python main.py path_original_image path_encoded_image
+  python3 main.py path_original_image path_encoded_image
   ```
 
 
 ## Example
 
-  python main.py ./lena.bmp ./lenadec.bmp
+  python3 main.py ./lena.bmp ./lenadec.bmp

--- a/imageReader.py
+++ b/imageReader.py
@@ -1,73 +1,70 @@
-#*********************************************************************************#
+# *********************************************************************************#
 # ImageReader Class                                                               #
 # This class contains the methods to read the image data                          #
 # Author: Marina Gonzalez                                                         #
 # Author: Eduardo Rodes Pastor                                                    #
-#*********************************************************************************#
+# *********************************************************************************#
 from PIL import Image
 
-#***********************************************************************#
-#	Function getImageData: This gets the width and height of an     #
-#	image (in pixels) and the total number of pixels of it.         #
-#	Input: image file                                               #
-#	Output: width (pixels), height (pixels), number of pixels       #
-#***********************************************************************#
-def getImageData(filename):
+
+def get_image_data(filename):
+    """
+    This gets the width and height of an image (in pixels) and the total number of pixels of it.
+    :param filename: image file
+    :return: width, height, number of pixels
+    """
+    im = Image.open(filename)
+    width = im.size[0]
+    height = im.size[1]
+    npix = im.size[0] * im.size[1]
+
+    return width, height, npix
 
 
-	im = Image.open(filename)
-	width = im.size[0]
-	height = im.size[1]
-	npix = im.size[0] * im.size[1]
+def get_rgb(filename, npix):
+    """
+    This gets the RGB values from a given file and saves them in three lists from a given file.
+    :param filename: image file
+    :param npix:  number of pixels
+    :return: r, g, b
+    """
+    # Getting image pixels RGB values
+    im = Image.open(filename)
+    rgb_im = im.convert('RGB')
 
-	return width, height, npix
-	
-#*********************************************************************************#
-#	Function getRGB: This gets the RGB values from a given file and saves     #
-#	them in three lists from a given file.                                    #
-#	Input: file, number of pixels of the file                                 #
-#	Output: r [], g [], b []                                                  #
-#*********************************************************************************#
-def getRGB(filename, npix):
+    # Creating three lists of npix items
+    r = [-1] * npix
+    g = [-1] * npix
+    b = [-1] * npix
 
-	# Getting image pixels RGB values
-	im = Image.open(filename)
-	rgb_im = im.convert('RGB')
+    for y in range(0, im.size[1]):
+        for x in range(0, im.size[0]):
+            # We get the RGB value in each pixel and save each component in an array
+            rpix, gpix, bpix = rgb_im.getpixel((x, y))
+            r[im.size[0] * y + x] = rpix
+            g[im.size[0] * y + x] = gpix
+            b[im.size[0] * y + x] = bpix
 
-	# Creating three lists of npix items
-	r = [-1] * npix 
-	g = [-1] * npix
-	b = [-1] * npix
+    return r, g, b
 
-	for y in range(0, im.size[1]):
-		for x in range(0, im.size[0]):
 
-			# We get the RGB value in each pixel and save each component in an array
-			rpix, gpix, bpix = rgb_im.getpixel((x,y)) 
-			r[im.size[0]*y + x] = rpix
-			g[im.size[0]*y + x] = gpix
-			b[im.size[0]*y + x] = bpix
+def rgb_to_yuv(r, g, b):  # in (0,255) range
+    """
+     This converts three lists (red, blue, green) in their equivalent YUV lists.
+    :param r:
+    :param g:
+    :param b:
+    :return: Y, Cb, Cr
+    """
+    # All of these lists have the same length
+    y = [0] * len(r)
+    cb = [0] * len(r)
+    cr = [0] * len(r)
 
-	return r, g, b
+    # This is just the formula to get YUV from RGB.
+    for i in range(0, len(r)):
+        y[i] = int(0.299 * r[i] + 0.587 * g[i] + 0.114 * b[i])
+        cb[i] = int(128 - 0.168736 * r[i] - 0.331364 * g[i] + 0.5 * b[i])
+        cr[i] = int(128 + 0.5 * r[i] - 0.418688 * g[i] - 0.081312 * b[i])
 
-#***********************************************************************#
-#	Function RGBtoYUV: This converts three lists (red, blue, green) #
-#	in their equivalent YUV lists.                                  #
-#	Input: r [], g [], b []                                         #
-#	Output: y [], cb [], cr []                                      #
-#***********************************************************************#
-def RGBtoYUV(r, g, b): # in (0,255) range
-
-	# All of these lists have the same length
-	y = [0] * len(r) 
-	cb = [0] * len(r) 
-	cr = [0] * len(r)
-
-	# This is just the formula to get YUV from RGB.
-	for i in range(0, len(r)): 		
-		y[i] = int(0.299 * r[i] + 0.587 * g[i] + 0.114 * b[i])
-		cb[i] = int(128 - 0.168736 * r[i] - 0.331364 * g[i] + 0.5 * b[i])
-		cr[i] = int(128 + 0.5 * r[i] - 0.418688 * g[i] - 0.081312 * b[i])
-
-	return y, cb, cr
-
+    return y, cb, cr

--- a/main.py
+++ b/main.py
@@ -1,37 +1,42 @@
-
-#*********************************************************************************#
+# *********************************************************************************#
 # PSNRtool                                                                        #
 # PSNRtool allows to calculate PSNR of two images                                 #
 # Author: Marina Gonzalez                                                         #
 # Author: Eduardo Rodes Pastor                                                    #
-#*********************************************************************************#
+# *********************************************************************************#
 
+import sys
 from optparse import OptionParser
 from imageReader import *
 from psnr import *
 
-if __name__=='__main__':
-	parser = OptionParser()
-	(options, args) = parser.parse_args()
-	
-	if (len(args) < 2):
-		print "ERROR: You should indicate original image and coder image. \n"
 
-	original = args[0]
-	encoded = args[1]
+def print_usage():
+    print('USAGE: {} ORIGINAL ENCODED'.format(sys.argv[0]))
 
-	original_width, original_height, original_npix = getImageData(original)
-	encoded_width, encoded_height, encoded_npix = getImageData(original)
 
-	if (original_width != encoded_width or original_height != encoded_height or original_npix != encoded_npix):
-		print "ERROR: Images should have same dimensions. \n"
+if __name__ == '__main__':
+    parser = OptionParser()
+    (options, args) = parser.parse_args()
 
-	# Getting YUV values
-	original_r, original_g, original_b = getRGB(original, original_npix)
-	original_y, original_cb, original_cr = RGBtoYUV(original_r, original_g, original_b)
+    if len(args) < 2:
+        print_usage()
 
-	encoded_r, encoded_g, encoded_b = getRGB(encoded, encoded_npix)
-	encoded_y, encoded_cb, encoded_cr = RGBtoYUV(encoded_r, encoded_g, encoded_b)
-	
-	calculatePSNR(original_y, encoded_y, original_cb, encoded_cb, original_cr, encoded_cr, original_npix)
+    original = args[0]
+    encoded = args[1]
 
+    original_width, original_height, original_npix = get_image_data(original)
+    encoded_width, encoded_height, encoded_npix = get_image_data(original)
+
+    if original_width != encoded_width or original_height != encoded_height or original_npix != encoded_npix:
+        print("ERROR: Images should have same dimensions. \n")
+        exit(1)
+
+    # Getting YUV values
+    original_r, original_g, original_b = get_rgb(original, original_npix)
+    original_y, original_cb, original_cr = rgb_to_yuv(original_r, original_g, original_b)
+
+    encoded_r, encoded_g, encoded_b = get_rgb(encoded, encoded_npix)
+    encoded_y, encoded_cb, encoded_cr = rgb_to_yuv(encoded_r, encoded_g, encoded_b)
+
+    calculate_psnr(original_y, encoded_y, original_cb, encoded_cb, original_cr, encoded_cr, original_npix)

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@
 
 import sys
 from optparse import OptionParser
+
 from imageReader import *
 from psnr import *
 

--- a/psnr.py
+++ b/psnr.py
@@ -1,56 +1,56 @@
-#*********************************************************************************#
+# *********************************************************************************#
 # PSNR Class                                                                      #
 # This class contains the methods for psnr calculations                           #
 # Author: Marina Gonzalez                                                         #
 # Author: Eduardo Rodes Pastor                                                    #
-#*********************************************************************************#
+# *********************************************************************************#
 
 import math
 
-#*********************************************************************************#
-#   Function calculatePSNR: This calculates the Peak Signal to Noise Ratio (PSNR) # 
-#   of the encoded image, comparing it to the original one.                       #
-#   Input: original y array, encoded y array, original cb array, encoded cb array,#
-#   original cr array, encoded cr array, number of pixels                         #
-#   Output: None, just prints the PSNR                                            #
-#*********************************************************************************#
 
-def calculatePSNR(original_y, encoded_y, original_cb, encoded_cb, original_cr, encoded_cr, npix):
+def calculate_psnr(original_y, encoded_y, original_cb, encoded_cb, original_cr, encoded_cr, npix):
+    """
+    This calculates the Peak Signal to Noise Ratio (PSNR) of the encoded image, comparing it to the original one.
+    :param original_y:
+    :param encoded_y:
+    :param original_cb:
+    :param encoded_cb:
+    :param original_cr:
+    :param encoded_cr:
+    :param npix:
+    :return:
+    """
+    error_y = 0  # Summatory of y squared errors
+    error_cb = 0  # Summatory of cr squared errors
+    error_cr = 0  # Summatory of cb squared errors
+    for i in range(0, len(original_y)):
+        dif_y = abs(original_y[i] - encoded_y[i])  # Simple error between predicted and original luminance
+        dif_cb = abs(original_cb[i] - encoded_cb[i])  # Simple error between predicted and original cb
+        dif_cr = abs(original_cr[i] - encoded_cr[i])  # Simple error between predicted and original cr
+        error_y += dif_y * dif_y  # We add y square to the summatory
+        error_cb += dif_cb * dif_cb  # We add cb square to the summatory
+        error_cr += dif_cr * dif_cr  # We add cr square to the summatory
 
-        error_y = 0 # Summatory of y squared errors
-	error_cb = 0 # Summatory of cr squared errors
-	error_cr = 0 # Summatory of cb squared errors
-        for i in range(0, len(original_y)): 
-                
-                dif_y = abs(original_y[i] - encoded_y[i])    # Simple error between predicted and original luminance
-		dif_cb = abs(original_cb[i] - encoded_cb[i]) # Simple error between predicted and original cb
-		dif_cr = abs(original_cr[i] - encoded_cr[i]) # Simple error between predicted and original cr
-                error_y += dif_y*dif_y    # We add y square to the summatory
-		error_cb += dif_cb*dif_cb # We add cb square to the summatory
-		error_cr += dif_cr*dif_cr # We add cr square to the summatory
-                         
-        meanSquaredErrorY = float(error_y) / float(npix) # And we get the mean squared error per pixel
-        meanSquaredErrorCb = float(error_cb) / float(npix) # And we get the mean squared error per pixel
-        meanSquaredErrorCr = float(error_cr) / float(npix) # And we get the mean squared error per pixel
-       
-	if (meanSquaredErrorY != 0):
-		# We use 255*255 because we're using 8 bits for every luminance value
-                peakSignalToNoiseRatioY = float(-10.0 * math.log(meanSquaredErrorY/(255 * 255), 10)) 
-        else:
-                peakSignalToNoiseRatioY = 0
+    mse_y = float(error_y) / float(npix)  # And we get the mean squared error per pixel
+    mse_cb = float(error_cb) / float(npix)  # And we get the mean squared error per pixel
+    mse_cr = float(error_cr) / float(npix)  # And we get the mean squared error per pixel
 
-	if (meanSquaredErrorCb != 0):
-		# We use 255*255 because we're using 8 bits for every luminance value
-                peakSignalToNoiseRatioCb = float(-10.0 * math.log(meanSquaredErrorCb/(255 * 255), 10)) 
-        else:
-                peakSignalToNoiseRatioCb = 0
+    if mse_y != 0:
+        # We use 255*255 because we're using 8 bits for every luminance value
+        psnr_y = float(-10.0 * math.log(mse_y / (255 * 255), 10))
+    else:
+        psnr_y = 0
 
-	if (meanSquaredErrorCr != 0):
-		# We use 255*255 because we're using 8 bits for every luminance value
-                peakSignalToNoiseRatioCr = float(-10.0 * math.log(meanSquaredErrorCr/(255 * 255), 10)) 
-        else:
-                peakSignalToNoiseRatioCr = 0
+    if mse_cb != 0:
+        # We use 255*255 because we're using 8 bits for every luminance value
+        psnr_cb = float(-10.0 * math.log(mse_cb / (255 * 255), 10))
+    else:
+        psnr_cb = 0
 
-	print 'Y = ', peakSignalToNoiseRatioY, ' Cb = ', peakSignalToNoiseRatioCb, ' Cr = ', peakSignalToNoiseRatioCr
+    if mse_cr != 0:
+        # We use 255*255 because we're using 8 bits for every luminance value
+        psnr_cr = float(-10.0 * math.log(mse_cr / (255 * 255), 10))
+    else:
+        psnr_cr = 0
 
-
+    print('Y = ', psnr_y, ' Cb = ', psnr_cb, ' Cr = ', psnr_cr)


### PR DESCRIPTION
Hi,

I edited your code to fit PEP8 standard and fixed errors which causing problems with Python3 (missing parenthesis on `print`s).

Maybe you can use `print` function from `__future__` package instead of Python 2 `print`.

Also edited README for Python 3.